### PR TITLE
seek to start of pin file before trying to read

### DIFF
--- a/pin.go
+++ b/pin.go
@@ -113,6 +113,11 @@ func OpenPin(number int, direction Direction) (*Pin, error) {
 
 // Read the current value of the pin.
 func (p *Pin) Read() (Value, error) {
+	// seek to beginning of file in case we've read it before
+	if _, err := p.value.Seek(0, 0); err != nil {
+		return LOW, err
+	}
+
 	d, err := ioutil.ReadAll(p.value)
 	if err != nil {
 		return LOW, err


### PR DESCRIPTION
This allows us to repeatedly read from the pin without having to close it every time. The sysfs documentation recommends using lseek(2) to return to the start of the file before each read:

https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
